### PR TITLE
Fix only code output display problem

### DIFF
--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name              KeepChatGPT
 // @description       这是一款提高ChatGPT的数据安全能力和效率的插件。并且免费共享大量创新功能，如：自动刷新、保持活跃、数据安全、取消审计、克隆对话、言无不尽、净化页面、展示大屏、拦截跟踪、日新月异、明察秋毫等。让我们的AI体验无比安全、顺畅、丝滑、高效、简洁。
-// @version           32.4
+// @version           32.5
 // @author            xcanwin
 // @namespace         https://github.com/xcanwin/KeepChatGPT/
 // @supportURL        https://github.com/xcanwin/KeepChatGPT/


### PR DESCRIPTION
当所有输出都是代码块包裹的时候，width:auto 会导致宽度为0然后显示异常，删除width auto可以解决这个问题，会导致宽度始终拉到最大，但不是严重问题（我认为是小于纯代码块输出看不了的）