### PR TITLE
修复展示大屏

### DIFF
--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name              KeepChatGPT
 // @description       这是一款提高ChatGPT的数据安全能力和效率的插件。并且免费共享大量创新功能，如：自动刷新、保持活跃、数据安全、取消审计、克隆对话、言无不尽、净化页面、展示大屏、拦截跟踪、日新月异、明察秋毫等。让我们的AI体验无比安全、顺畅、丝滑、高效、简洁。
-// @version           32.5
+// @version           32.6
 // @author            xcanwin
 // @namespace         https://github.com/xcanwin/KeepChatGPT/
 // @supportURL        https://github.com/xcanwin/KeepChatGPT/
@@ -587,7 +587,7 @@
             } else {
                 sv("k_largescreen", true);
             }
-            document.documentElement.classList.toggle('largescreen');
+            $("main.transition-width").classList.toggle('largescreen');
             $('.checkbutton', this).classList.toggle('checked');
         };
 
@@ -671,7 +671,7 @@
 
         if (gv("k_largescreen", false) === true) {
             $('#nmenuid_ls .checkbutton').classList.add('checked');
-            document.documentElement.classList.add('largescreen');
+            $("main.transition-width").classList.add('largescreen');
         }
 
         if (gv("k_speakcompletely", false) === true) {


### PR DESCRIPTION
Changed the target for toggling and adding the 'largescreen' class from the main element to the document's root element. This ensures the 'largescreen' style is applied globally rather than just to the main content area.

#510 

修复方案由[SuSu19996](https://github.com/SuSu19996)贡献，并已经验证有效