### PR TITLE
fix(sidebar): remove hidden tiny rail gap

### DIFF
--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -106,7 +106,8 @@
     };
 
     const u = `/api/${GM_info.script.namespace.slice(33, 34)}uth/s${GM_info.script.namespace.slice(28, 29)}ssion`;
-    const symbol1_selector = "nav.flex:not(#stage-sidebar-tiny-bar):not([inert])";
+    const symbol1_selector =
+        "nav.flex:not(#stage-sidebar-tiny-bar):not([inert]):not(:where([inert] *))";
     const symbol2_selector =
         "div.sticky div.justify-center.top-0 button span.sr-only";
     const trackingHostRegex =
@@ -1921,8 +1922,12 @@ ${symbol1_selector} div.pt-3\\.5 {
     max-height: 0 !important;
 }
 
-/* ChatGPT sidebar compatibility: collapse the hidden tiny rail without deleting it. */
-#stage-sidebar-tiny-bar {
+/* ChatGPT sidebar compatibility: only collapse the tiny rail when the
+   adjacent expanded sidebar pane is active. In collapsed mode, this rail
+   owns the visible sidebar controls. */
+#stage-sidebar-tiny-bar:has(+ div:not([inert]):not(.opacity-0):not(.pointer-events-none) nav[aria-label="Chat history"]),
+#stage-sidebar-tiny-bar:has(+ div:not([inert]):not(.opacity-0):not(.pointer-events-none) nav[aria-label="Sidebar"]),
+#stage-sidebar-tiny-bar:has(+ div:not([inert]):not(.opacity-0):not(.pointer-events-none) #history) {
     display: none !important;
     width: 0 !important;
     min-width: 0 !important;

--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -106,7 +106,7 @@
     };
 
     const u = `/api/${GM_info.script.namespace.slice(33, 34)}uth/s${GM_info.script.namespace.slice(28, 29)}ssion`;
-    const symbol1_selector = "nav.flex";
+    const symbol1_selector = "nav.flex:not(#stage-sidebar-tiny-bar):not([inert])";
     const symbol2_selector =
         "div.sticky div.justify-center.top-0 button span.sr-only";
     const trackingHostRegex =
@@ -1201,6 +1201,7 @@
             let gpt_menu = fp(".no-draggable", $(symbol2_selector), 4);
             gpt_menu.classList.remove('absolute');
         } */
+        if (!symbol_prt) return;
         symbol_prt.insertBefore(ndivkcg, symbol_prt.childNodes[0]);
         loadMenu();
 
@@ -1247,29 +1248,29 @@
 /*日星月异*/
 .ever-changing {
     /*左边栏*/
-    nav.flex {
+    ${symbol1_selector} {
         background: linear-gradient(to right top, #d0dcff, #f0f0ff, #fff3f3);
     }
     /*左边栏顶部选项*/
-    nav.flex .top-0 {
+    ${symbol1_selector} .top-0 {
         background: linear-gradient(to top, #f0f0ff, #fff3f3);
     }
     /*左边栏顶部工具*/
-    nav.flex aside {
+    ${symbol1_selector} aside {
         background: linear-gradient(to top, #efebff, #f0f0ff);
     }
-    nav.flex #history>div {
+    ${symbol1_selector} #history>div {
         height: 3.5rem;
         background-color: rgba(255, 255, 255, 0.4);
     }
-    nav.flex #history>div>a {
+    ${symbol1_selector} #history>div>a {
         mask-image: unset !important;
     }
-    nav.flex #history>div .bg-gradient-to-l {
+    ${symbol1_selector} #history>div .bg-gradient-to-l {
         background-image: unset;
     }
 
-    nav.flex #history::after {
+    ${symbol1_selector} #history::after {
         content: "";
         display: block;
         height: 1px;
@@ -1277,11 +1278,11 @@
     }
 
     /*左边栏选中条目*/
-    nav.flex #history>div.bg-token-sidebar-surface-tertiary {
+    ${symbol1_selector} #history>div.bg-token-sidebar-surface-tertiary {
         background-color: #bfcbfd;
     }
     /*左边栏鼠标滑动*/
-    nav.flex #history>div:hover {
+    ${symbol1_selector} #history>div:hover {
         background-color: #d5ddff;
     }
 
@@ -1302,46 +1303,46 @@
 /*官方暗色模式*/
 .dark {
     .ever-changing {
-        nav.flex {
+        ${symbol1_selector} {
             background: linear-gradient(to right top, #171717, #060606, #171717);
         }
         /*左边栏顶部选项*/
-        nav.flex .top-0 {
+        ${symbol1_selector} .top-0 {
             background: linear-gradient(to top, #060606, #0f0f0f);
         }
         /*左边栏顶部工具*/
-        nav.flex aside {
+        ${symbol1_selector} aside {
             background: linear-gradient(to top, #111, #060606);
         }
-        nav.flex #history>div {
+        ${symbol1_selector} #history>div {
             height: 3.5rem;
             background-color: rgba(111, 111, 111, 0.25);
         }
-        nav.flex #history>div>a {
+        ${symbol1_selector} #history>div>a {
             mask-image: unset !important;
         }
-        nav.flex #history>div .bg-gradient-to-l {
+        ${symbol1_selector} #history>div .bg-gradient-to-l {
             background-image: unset;
         }
 
-        nav.flex #history::after {
+        ${symbol1_selector} #history::after {
             content: "";
             display: block;
             height: 1px;
             background: linear-gradient(to right, transparent, #535353, transparent);
         }
-        nav.flex #history>div.bg-token-sidebar-surface-tertiary {
+        ${symbol1_selector} #history>div.bg-token-sidebar-surface-tertiary {
             background-color: #444;
         }
-        nav.flex #history>div:hover {
+        ${symbol1_selector} #history>div:hover {
             background-color: #2f2f2f;
         }
 
-        nav.flex #history a .navtitle {
+        ${symbol1_selector} #history a .navtitle {
             color: #f4f4f4 !important;
         }
 
-        nav.flex #history a .navlast {
+        ${symbol1_selector} #history a .navlast {
             color: #d0d0d0 !important;
         }
 
@@ -1767,7 +1768,7 @@ body.kdark .kdialogclose {
 .kpurifypage {
     main .text-token-text-primary .mb-5.font-medium /*游客模式的首页的LOGO下方的问候语*/,
     form.w-full .grow .bottom-full /*游客模式的首页的快捷提示词*/,
-    nav.flex .mb-4 /*游客模式的侧边栏的登录提醒*/,
+    ${symbol1_selector} .mb-4 /*游客模式的侧边栏的登录提醒*/,
     main .text-token-text-primary .mx-3.items-stretch /*首页的LOGO下方的快捷提示词*/,
     main div.shadow-xxs /*输入框上方的GPT-4o的上限提示*/,
     main form .text-token-text-secondary /*输入框上方标签*/,
@@ -1862,11 +1863,11 @@ body.kdark .kdialogclose {
 }
 
 /*侧边栏*/
-nav {
+${symbol1_selector} {
     position: relative;
     scrollbar-width: thin;
 }
-nav div.pt-3\\.5 {
+${symbol1_selector} div.pt-3\\.5 {
     padding-bottom: .5rem;
     padding-top: .25rem;
 }
@@ -1920,10 +1921,21 @@ nav div.pt-3\\.5 {
     max-height: 0 !important;
 }
 
-nav.flex div.overflow-y-auto a.hover\\:pr-4 {
+/* ChatGPT sidebar compatibility: collapse the hidden tiny rail without deleting it. */
+#stage-sidebar-tiny-bar {
+    display: none !important;
+    width: 0 !important;
+    min-width: 0 !important;
+    max-width: 0 !important;
+    flex-basis: 0 !important;
+    overflow: hidden !important;
+    pointer-events: none !important;
+}
+
+${symbol1_selector} div.overflow-y-auto a.hover\\:pr-4 {
     padding-right: unset;
 }
-nav.flex div.overflow-y-auto {
+${symbol1_selector} div.overflow-y-auto {
     scrollbar-width: thin;
 }
 .gptm {
@@ -1935,7 +1947,7 @@ nav.flex div.overflow-y-auto {
     color: white;
 }
 
-nav.flex .transition-all {
+${symbol1_selector} .transition-all {
     position: unset;
 }
 
@@ -2334,12 +2346,12 @@ nav.flex .transition-all {
 
     const everChanging = function (action) {
         if (action === true) {
-            $("nav.flex")?.classList.add("knav");
+            $(symbol1_selector)?.classList.add("knav");
             $("body").classList.add("ever-changing");
             everChanging.startObserver();
             scheduleEverChangingAttach(undefined, 60);
         } else {
-            $("nav.flex")?.classList.remove("knav");
+            $(symbol1_selector)?.classList.remove("knav");
             $("body").classList.remove("ever-changing");
             everChanging.stopObserver();
             $$("[data-kcg-everchanging='true']").forEach((el) => el.remove());
@@ -2376,7 +2388,7 @@ nav.flex .transition-all {
     };
 
     const attachDate = function (kec_object) {
-        $$("nav.flex a[href*='/c/']").forEach(async (el) => {
+        $$(`${symbol1_selector} a[href*='/c/']`).forEach(async (el) => {
             let a_id;
             const a_id_m = el.href.match(
                 "/(([^/]{4,}?){4}-[^/]{4,}?)(\\?|$)(\\?|$)",
@@ -2472,7 +2484,7 @@ ${previewText ? `<br>
             }
         });
 
-        const sidebar_chat = $("nav.flex div.overflow-y-auto");
+        const sidebar_chat = $(`${symbol1_selector} div.overflow-y-auto`);
         if (sidebar_chat) {
             if (sidebar_chat.scrollHeight > sidebar_chat.clientHeight) {
                 sidebar_chat.classList.add("-mr-2");
@@ -2898,7 +2910,7 @@ ${previewText ? `<br>
 
     const bootKCG = function () {
         if (kcgBooted) return;
-        if (!($(symbol1_selector) || $(symbol2_selector))) return;
+        if (!$(symbol1_selector)) return;
 
         kcgBooted = true;
         if (kcgBootTimer) {
@@ -2926,7 +2938,7 @@ ${previewText ? `<br>
 
         onDomStable(() => {
             if (kcgBooted) return;
-            if (!($(symbol1_selector) || $(symbol2_selector))) return;
+            if (!$(symbol1_selector)) return;
 
             if (kcgBootTimer) {
                 clearTimeout(kcgBootTimer);


### PR DESCRIPTION
Collapse ChatGPT's hidden `#stage-sidebar-tiny-bar` when the expanded sidebar is active. The hidden rail could still affect layout and create a large blank gap above the sidebar content when KeepChatGPT was enabled.

Scope sidebar selectors to the visible, non-inert sidebar, keep the existing KeepChatGPT mount path, and preserve `More Chat Info` behavior without deleting ChatGPT-managed sidebar nodes or forcing sidebar scroll
position.