### PR TITLE
修复大屏模式下输入框未居中

### DIFF
--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name              KeepChatGPT
 // @description       这是一款提高ChatGPT的数据安全能力和效率的插件。并且免费共享大量创新功能，如：自动刷新、保持活跃、数据安全、取消审计、克隆对话、言无不尽、净化页面、展示大屏、拦截跟踪、日新月异、明察秋毫等。让我们的AI体验无比安全、顺畅、丝滑、高效、简洁。
-// @version           34.10
+// @version           34.20
 // @author            xcanwin
 // @namespace         https://github.com/xcanwin/KeepChatGPT/
 // @supportURL        https://github.com/xcanwin/KeepChatGPT/
@@ -1904,6 +1904,7 @@ ${symbol1_selector} div.pt-3\\.5 {
         #thread-bottom>div>div>div {
             width: 100% !important;
             max-width: min(90rem, calc(100vw - 8rem)) !important;
+            margin-inline: auto !important;
         }
         form.w-full {
             max-width: 100% !important;

--- a/KeepChatGPT.user.js
+++ b/KeepChatGPT.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name              KeepChatGPT
 // @description       这是一款提高ChatGPT的数据安全能力和效率的插件。并且免费共享大量创新功能，如：自动刷新、保持活跃、数据安全、取消审计、克隆对话、言无不尽、净化页面、展示大屏、拦截跟踪、日新月异、明察秋毫等。让我们的AI体验无比安全、顺畅、丝滑、高效、简洁。
-// @version           34.20
+// @version           34.11
 // @author            xcanwin
 // @namespace         https://github.com/xcanwin/KeepChatGPT/
 // @supportURL        https://github.com/xcanwin/KeepChatGPT/


### PR DESCRIPTION
## 变更背景

在 4K 分辨率下开启“大屏展示”后，ChatGPT 对话输入框会偏向页面左侧；关闭脚本后输入框恢复居中。1920×1080 分辨率下该问题不明显。

## 改动范围

- 为大屏模式下扩宽后的消息区和输入区增加水平自动边距
- 保持现有最大宽度和大屏展示逻辑不变

## 修复原理

大屏模式为消息区和输入区设置最大宽度后，4K 分辨率下容器宽度小于可用空间，但没有明确设置水平居中。

增加以下样式，使左右剩余空间平均分配：

```css
margin-inline: auto !important;